### PR TITLE
[feature] Add DB layer for accessing the new experiments table

### DIFF
--- a/api/internal/db/db_mocks.go
+++ b/api/internal/db/db_mocks.go
@@ -53,7 +53,7 @@ func (e *ExperimentRunsMock) ListExperimentRunIdsForReconciliation(_ context.Con
 	return runIds, nil
 }
 
-func (e *ExperimentRunsMock) UpdateExperimentRunTimestamp(_ context.Context, id int64) error {
+func (e *ExperimentRunsMock) UpdateExperimentRunUpdatedAndTimestamp(_ context.Context, id int64, updated bool, ts time.Time) error {
 	for _, run := range e.ExperimentRuns {
 		if run.Id == id {
 			run.UpdatedTs = run.UpdatedTs.Add(1)
@@ -78,6 +78,46 @@ var _ ExperimentRunService = &ExperimentRunsMock{}
 
 type ExperimentsMock struct {
 	Experiments []*Experiment
+}
+
+func (e *ExperimentsMock) GetExperimentById(ctx context.Context, id int64) (*Experiment, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) GetExperimentByExperimentId(ctx context.Context, experimentId string) (*Experiment, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) ListExperimentIDsForReconciliation(ctx context.Context, maxItems int64) ([]int64, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) MarkExperimentIDForReconciliation(ctx context.Context, id int64) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) UpdateRemoteExperimentId(ctx context.Context, id int64, remoteExperimentId string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) UpdateExperimentCreatedAndTimestamp(ctx context.Context, id int64, created bool, ts time.Time) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) UpdateExperimentUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, ts time.Time) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (e *ExperimentsMock) CreateExperiment(ctx context.Context, experimentId string, createdTs time.Time, updatedTs time.Time) (*Experiment, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (e *ExperimentsMock) ListExperiments(_ context.Context) ([]*Experiment, error) {

--- a/api/internal/db/experiment-runs.go
+++ b/api/internal/db/experiment-runs.go
@@ -11,7 +11,7 @@ type ExperimentRunService interface {
 	GetExperimentRun(ctx context.Context, experimentId string, runId string) (*ExperimentRun, error)
 	ListExperimentRuns(ctx context.Context, experimentId string) ([]*ExperimentRun, error)
 	ListExperimentRunIdsForReconciliation(ctx context.Context, maxItems int64) ([]int64, error)
-	UpdateExperimentRunTimestamp(ctx context.Context, id int64) error
+	UpdateExperimentRunUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, updatedAt time.Time) error
 	DeleteExperimentRun(ctx context.Context, experimentId string, runId string) error
 }
 
@@ -19,6 +19,7 @@ type ExperimentRun struct {
 	Id           int64
 	ExperimentId string
 	RunId        string
+	RemoteRunId  string
 	Created      bool
 	Updated      bool
 	Deleted      bool

--- a/api/internal/db/experiments.go
+++ b/api/internal/db/experiments.go
@@ -2,13 +2,29 @@ package db
 
 import (
 	"context"
+	"time"
 )
 
 type Experiment struct {
-	Id           int64
-	ExperimentId string
+	Id                 int64
+	ExperimentId       string
+	RemoteExperimentId string
+	Name               string
+	Created            bool
+	Updated            bool
+	Deleted            bool
+	CreatedTs          time.Time
+	UpdatedTs          time.Time
 }
 
 type ExperimentService interface {
+	GetExperimentById(ctx context.Context, id int64) (*Experiment, error)
+	GetExperimentByExperimentId(ctx context.Context, experimentId string) (*Experiment, error)
 	ListExperiments(ctx context.Context) ([]*Experiment, error)
+	ListExperimentIDsForReconciliation(ctx context.Context, maxItems int64) ([]int64, error)
+	MarkExperimentIDForReconciliation(ctx context.Context, id int64) error
+	UpdateRemoteExperimentId(ctx context.Context, id int64, remoteExperimentId string) error
+	UpdateExperimentCreatedAndTimestamp(ctx context.Context, id int64, created bool, ts time.Time) error
+	UpdateExperimentUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, ts time.Time) error
+	CreateExperiment(ctx context.Context, experimentId string, createdTs time.Time, updatedTs time.Time) (*Experiment, error)
 }

--- a/api/internal/db/sqlite/experiment-runs.go
+++ b/api/internal/db/sqlite/experiment-runs.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/db"
 	lsql "github.infra.cloudera.com/CAI/AmpRagMonitoring/pkg/sql"
+	"time"
 )
 
 type ExperimentRuns struct {
@@ -121,13 +122,13 @@ func (e *ExperimentRuns) ListExperimentRunIdsForReconciliation(ctx context.Conte
 	return response, nil
 }
 
-func (e *ExperimentRuns) UpdateExperimentRunTimestamp(ctx context.Context, id int64) error {
+func (e *ExperimentRuns) UpdateExperimentRunUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, updatedAt time.Time) error {
 	query := `
 	UPDATE experiment_runs
-	SET updated_ts = datetime('now')
+	SET updated = ?, updated_ts = datetime('now')
 	WHERE id = ? 
 	`
-	args := []interface{}{id}
+	args := []interface{}{updated, updatedAt, id}
 	_, err := e.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return err

--- a/api/internal/db/sqlite/experiments.go
+++ b/api/internal/db/sqlite/experiments.go
@@ -2,8 +2,11 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	log "github.com/sirupsen/logrus"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/db"
 	lsql "github.infra.cloudera.com/CAI/AmpRagMonitoring/pkg/sql"
+	"time"
 )
 
 type Experiments struct {
@@ -18,10 +21,146 @@ func NewExperiments(instance *lsql.Instance) db.ExperimentService {
 	}
 }
 
+func (e *Experiments) CreateExperiment(ctx context.Context, experimentId string, createdTs time.Time, updatedTs time.Time) (*db.Experiment, error) {
+	query := `
+	INSERT INTO experiments (experiment_id, created, created_ts, updated, updated_ts, deleted) VALUES (?, true, ?, false, ?, false)
+	`
+	id, err := e.db.ExecAndReturnId(ctx, query, experimentId, createdTs, updatedTs)
+	if err != nil {
+		return nil, err
+	}
+	return e.GetExperimentById(ctx, id)
+}
+
+func (e *Experiments) UpdateRemoteExperimentId(ctx context.Context, id int64, remoteExperimentId string) error {
+	query := `
+	UPDATE experiments SET remote_experiment_id=?
+	WHERE id = ?
+	`
+	res, err := e.db.ExecContext(ctx, query, remoteExperimentId, id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		log.Printf("no rows affected for experiment %d", id)
+	}
+	return nil
+}
+
+func (e *Experiments) UpdateExperimentCreatedAndTimestamp(ctx context.Context, id int64, created bool, ts time.Time) error {
+	query := `
+	UPDATE experiments SET created=?, created_ts=?
+	WHERE id = ?
+	`
+	res, err := e.db.ExecContext(ctx, query, created, ts, id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		log.Printf("no rows affected for experiment %d", id)
+	}
+	return nil
+}
+
+func (e *Experiments) UpdateExperimentUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, ts time.Time) error {
+	query := `
+	UPDATE experiments SET updated=?, updated_at=?
+	WHERE id = ?
+	`
+	res, err := e.db.ExecContext(ctx, query, updated, ts, id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		log.Printf("no rows affected for experiment %d", id)
+	}
+	return nil
+}
+
+func (e *Experiments) GetExperimentById(ctx context.Context, id int64) (*db.Experiment, error) {
+	query := `
+	SELECT id, experiment_id, remote_experiment_id, created, updated, deleted, created_ts, updated_ts
+	FROM experiments
+	WHERE id = ?
+	`
+	row := e.db.QueryRowContext(ctx, query, id)
+
+	experiment, err := e.experimentFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return experiment, nil
+}
+
+func (e *Experiments) GetExperimentByExperimentId(ctx context.Context, experimentId string) (*db.Experiment, error) {
+	query := `
+	SELECT id, experiment_id, remote_experiment_id, created, updated, deleted, created_ts, updated_ts
+	FROM experiments
+	WHERE experiment_id = ?
+	`
+	row := e.db.QueryRowContext(ctx, query, experimentId)
+
+	experiment, err := e.experimentFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return experiment, nil
+}
+
+func (e *Experiments) experimentFromRow(row lsql.RowScanner) (*db.Experiment, error) {
+	experiment := &db.Experiment{}
+	remoteExperimentId := sql.NullString{}
+	if err := row.Scan(&experiment.Id, &experiment.ExperimentId, &remoteExperimentId, &experiment.Created, &experiment.Updated, &experiment.Deleted, &experiment.CreatedTs, &experiment.UpdatedTs); err != nil {
+		return nil, err
+	}
+	if remoteExperimentId.Valid {
+		experiment.RemoteExperimentId = remoteExperimentId.String
+	}
+	return experiment, nil
+}
+
+func (e *Experiments) MarkExperimentIDForReconciliation(ctx context.Context, id int64) error {
+	query := `
+	UPDATE experiments SET updated=?, updated_ts=?
+	WHERE id = ?
+	`
+	res, err := e.db.ExecContext(ctx, query, true, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		log.Printf("no rows affected for experiment %d", id)
+	}
+	return nil
+}
+
+func (e *Experiments) ListExperimentIDsForReconciliation(ctx context.Context, maxItems int64) ([]int64, error) {
+	query := `
+	SELECT id
+	FROM experiments
+	WHERE created = true OR updated = true
+	`
+	rows, err := e.db.QueryContext(ctx, query)
+
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
 func (e *Experiments) ListExperiments(ctx context.Context) ([]*db.Experiment, error) {
 	query := `
-	SELECT id, experiment_id
-	FROM experiment_runs
+	SELECT id, experiment_id, remote_experiment_id, created, updated, deleted, created_ts, updated_ts
+	FROM experiments
 	`
 	rows, err := e.db.QueryContext(ctx, query)
 
@@ -30,8 +169,8 @@ func (e *Experiments) ListExperiments(ctx context.Context) ([]*db.Experiment, er
 	}
 	response := make([]*db.Experiment, 0)
 	for rows.Next() {
-		experiment := &db.Experiment{}
-		if err := rows.Scan(&experiment.Id, &experiment.ExperimentId); err != nil {
+		experiment, err := e.experimentFromRow(rows)
+		if err != nil {
 			return nil, err
 		}
 		response = append(response, experiment)


### PR DESCRIPTION
Create the database interface layer to support syncing MLFlow experiments and runs from a local to remote instance.