### PR TITLE
fix: move in/out length to metrics

### DIFF
--- a/ragmon/utils/evaluate.py
+++ b/ragmon/utils/evaluate.py
@@ -199,6 +199,8 @@ async def evaluate_json_data(data):
                 "maliciousness_score": maliciousness.score,
                 "toxicity_score": toxicity.score,
                 "comprehensiveness_score": comprehensiveness.score,
+                "output_length": len(response.split()),
+                "input_length": len(query.split()),
             }
 
             # Log the metrics


### PR DESCRIPTION
- Moves input and output length logging to mlflow metrics
<img width="1233" alt="Screenshot 2024-12-11 at 3 55 00 PM" src="https://github.com/user-attachments/assets/9559ded1-5dbb-4220-9d3b-2792f95d8221" />
