### PR TITLE
fix: Correct a typo in the MLFlow URL used to fetch Runs

### DIFF
--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -124,7 +124,8 @@ func (m *MLFlow) Metrics(ctx context.Context, runId string) ([]Metric, error) {
 	if runId == "" {
 		return nil, fmt.Errorf("runId is required")
 	}
-	url := fmt.Sprintf("%s/api/2.0/runs/runs/get?run_id=%s", m.baseUrl, runId)
+	url := fmt.Sprintf("%s/api/2.0/mlflow/runs/get?run_id=%s", m.baseUrl, runId)
+
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
@@ -132,6 +133,7 @@ func (m *MLFlow) Metrics(ctx context.Context, runId string) ([]Metric, error) {
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
+		log.Printf("metrics not found for run %s", runId)
 		return []Metric{}, nil
 	}
 	defer resp.Body.Close()

--- a/api/internal/db/sqlite/experiment-runs.go
+++ b/api/internal/db/sqlite/experiment-runs.go
@@ -22,8 +22,8 @@ func NewExperimentRuns(instance *lsql.Instance) db.ExperimentRunService {
 
 func (e *ExperimentRuns) CreateExperimentRun(ctx context.Context, run *db.ExperimentRun) (*db.ExperimentRun, error) {
 	query := `
-	INSERT INTO experiment_runs (experiment_id, run_id)
-	VALUES (?, ?)
+	INSERT INTO experiment_runs (experiment_id, run_id, updated)
+	VALUES (?, ?, 1)
 	`
 	args := []interface{}{run.ExperimentId, run.RunId}
 	id, err := e.db.ExecAndReturnId(ctx, query, args...)
@@ -95,7 +95,7 @@ func (e *ExperimentRuns) ListExperimentRunIdsForReconciliation(ctx context.Conte
 	query := `
 	SELECT id
 	FROM experiment_runs
-	WHERE deleted = 0 AND updated_ts < datetime('now', '-1 minutes')
+	WHERE deleted = 0 AND updated = 1
 	LIMIT ?
 	`
 

--- a/api/internal/restapi/experiment-runs-api.go
+++ b/api/internal/restapi/experiment-runs-api.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"context"
+	log "github.com/sirupsen/logrus"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/db"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/models"
 	lhttp "github.infra.cloudera.com/CAI/AmpRagMonitoring/pkg/http"
@@ -50,6 +51,7 @@ func (e ExperimentRunsAPI) PostRuns(ctx context.Context, params runs.PostRunsPar
 	if params.Body.ExperimentRunID == "" {
 		return nil, lhttp.NewBadRequest("experiment_run_id is required")
 	}
+	log.Printf("Creating experiment run %s for experiment %s", params.Body.ExperimentRunID, params.Body.ExperimentID)
 	run, err := e.db.ExperimentRuns().CreateExperimentRun(ctx, &db.ExperimentRun{
 		ExperimentId: params.Body.ExperimentID,
 		RunId:        params.Body.ExperimentRunID,


### PR DESCRIPTION
The MLFlow url was corrected to `api/2.0/mlflow/runs` from `api/2.0/runs/runs`

Added debug logging to confirm that the REST API has been notified of a new Run.
Demoted chatty metrics reconciler debug output.