### PR TITLE
feature: Enable the experiment reconciler for local MLFLow experiment detection

### DIFF
--- a/api/internal/db/sqlite/experiments.go
+++ b/api/internal/db/sqlite/experiments.go
@@ -64,7 +64,7 @@ func (e *Experiments) UpdateExperimentCreatedAndTimestamp(ctx context.Context, i
 
 func (e *Experiments) UpdateExperimentUpdatedAndTimestamp(ctx context.Context, id int64, updated bool, ts time.Time) error {
 	query := `
-	UPDATE experiments SET updated=?, updated_at=?
+	UPDATE experiments SET updated=?, updated_ts=?
 	WHERE id = ?
 	`
 	res, err := e.db.ExecContext(ctx, query, updated, ts, id)

--- a/api/internal/reconcilers/reconcilers.go
+++ b/api/internal/reconcilers/reconcilers.go
@@ -55,14 +55,14 @@ func NewReconcilerSet(app *app.Instance, experimentsCfg *experiments.Config, exp
 }
 
 func (r *ReconcilerSet) Start() {
-	//r.experimentManager.Start()
+	r.experimentManager.Start()
 	//r.syncManager.Start()
 	//r.runManager.Start()
 	r.metricsManager.Start()
 }
 
 func (r *ReconcilerSet) Finish() {
-	//r.experimentManager.Finish()
+	r.experimentManager.Finish()
 	//r.syncManager.Finish()
 	//r.runManager.Finish()
 	r.metricsManager.Finish()


### PR DESCRIPTION
Scans the MLFlow instance for experiments and queues reconciliation for experiment runs when changes are detected.