### PR TITLE
feature: Enable the MLFLow sync reconciler to synchronize experiments

### DIFF
--- a/api/internal/datasource/config.go
+++ b/api/internal/datasource/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	LocalMLFlowBaseUrl string `env:"LOCAL_MLFLOW_BASE_URL" envDefault:"http://localhost:5000"`
 	CDSWMLFlowBaseUrl  string `env:"CDSW_API_URL" envDefault:""`
 	CDSWProjectNum     string `env:"CDSW_PROJECT_NUM" envDefault:""`
+	CDSWApiKey         string `env:"CDSW_API_KEY" envDefault:""`
 }
 
 func NewConfigFromEnv() (*Config, error) {
@@ -23,6 +24,9 @@ func NewConfigFromEnv() (*Config, error) {
 	}
 	if cfg.CDSWProjectNum == "" {
 		return nil, errors.New("CDSW_PROJECT_NUM is required")
+	}
+	if cfg.CDSWApiKey == "" {
+		return nil, errors.New("CDSW_API_KEY is required")
 	}
 
 	return &cfg, nil

--- a/api/internal/datasource/config.go
+++ b/api/internal/datasource/config.go
@@ -8,7 +8,7 @@ import (
 type Config struct {
 	LocalMLFlowBaseUrl string `env:"LOCAL_MLFLOW_BASE_URL" envDefault:"http://localhost:5000"`
 	CDSWMLFlowBaseUrl  string `env:"CDSW_API_URL" envDefault:""`
-	CDSWProjectNum     string `env:"CDSW_PROJECT_NUM" envDefault:""`
+	CDSWProjectID      string `env:"CDSW_PROJECT_ID" envDefault:""`
 	CDSWApiKey         string `env:"CDSW_API_KEY" envDefault:""`
 }
 
@@ -22,8 +22,8 @@ func NewConfigFromEnv() (*Config, error) {
 	if cfg.CDSWMLFlowBaseUrl == "" {
 		return nil, errors.New("CDSW_API_URL is required")
 	}
-	if cfg.CDSWProjectNum == "" {
-		return nil, errors.New("CDSW_PROJECT_NUM is required")
+	if cfg.CDSWProjectID == "" {
+		return nil, errors.New("CDSW_PROJECT_ID is required")
 	}
 	if cfg.CDSWApiKey == "" {
 		return nil, errors.New("CDSW_API_KEY is required")

--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -80,6 +80,7 @@ func (m *MLFlow) ListRuns(ctx context.Context, experimentId string) ([]*Run, err
 			return nil, err
 		}
 		req.Body = io.NopCloser(bytes.NewReader(encoded))
+		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := m.connections.HttpClient.Do(req)
 		if err != nil {
@@ -208,10 +209,10 @@ func (m *MLFlow) GetArtifact(ctx context.Context, runId string, path string) ([]
 }
 
 func (m *MLFlow) CreateExperiment(ctx context.Context, name string) (string, error) {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments", m.baseUrl, m.cfg.CDSWProjectNum)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments", m.baseUrl, m.cfg.CDSWProjectID)
 	req := cbhttp.NewRequest(ctx, "POST", url)
 	body := map[string]interface{}{
-		"project_id": m.cfg.CDSWProjectNum,
+		"project_id": m.cfg.CDSWProjectID,
 		"name":       name,
 	}
 	encoded, err := json.Marshal(body)

--- a/api/internal/datasource/platform_mlflow.go
+++ b/api/internal/datasource/platform_mlflow.go
@@ -40,6 +40,7 @@ func (m *PlatformMLFlow) UpdateRun(ctx context.Context, run *Run) error {
 	req.Body = io.NopCloser(bytes.NewReader(encoded))
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		log.Printf("failed to update run %s: %s", run.Info.RunId, err)
@@ -62,6 +63,7 @@ func (m *PlatformMLFlow) GetRun(ctx context.Context, experimentId string, runId 
 
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		log.Printf("failed to fetch run %s: %s", runId, err)
@@ -97,6 +99,7 @@ func (m *PlatformMLFlow) ListRuns(ctx context.Context, experimentId string) ([]*
 		req := cbhttp.NewRequest(ctx, "GET", url)
 		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 		resp, err := m.connections.HttpClient.Do(req)
 		if err != nil {
 			log.Printf("failed to fetch runs for experiment %s: %s", experimentId, err)
@@ -146,6 +149,7 @@ func (m *PlatformMLFlow) CreateRun(ctx context.Context, experimentId string, nam
 	req.Body = io.NopCloser(bytes.NewReader(encoded))
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		log.Printf("failed to create experiment %s: %s", name, err)
@@ -185,6 +189,7 @@ func (m *PlatformMLFlow) CreateExperiment(ctx context.Context, name string) (str
 	req.Body = io.NopCloser(bytes.NewReader(encoded))
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		log.Printf("failed to create experiment %s: %s", name, err)
@@ -218,10 +223,11 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 		if done {
 			break
 		}
-		url := fmt.Sprintf("%s/api/v2/experiments?page_size=%d&page_token=%s", m.baseUrl, maxItems, token)
+		url := fmt.Sprintf("%s/api/v2/projects/%s/experiments?page_size=%d&page_token=%s", m.baseUrl, m.cfg.CDSWProjectNum, maxItems, token)
 		req := cbhttp.NewRequest(ctx, "GET", url)
 		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 		resp, err := m.connections.HttpClient.Do(req)
 		if err != nil {
 			log.Printf("failed to fetch experiments: %s", err)
@@ -261,10 +267,11 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 }
 
 func (m *PlatformMLFlow) GetExperiment(ctx context.Context, experimentId string) (*Experiment, error) {
-	url := fmt.Sprintf("%s/api/2.0/mlflow/experiments/get?experiment_id=%s", m.baseUrl, experimentId)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/get?experiment_id=%s", m.baseUrl, m.cfg.CDSWProjectNum, experimentId)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		log.Printf("failed to fetch experiment %s: %s", experimentId, err)

--- a/api/internal/datasource/platform_mlflow.go
+++ b/api/internal/datasource/platform_mlflow.go
@@ -12,6 +12,22 @@ import (
 	"time"
 )
 
+type PlatformExperiment struct {
+	Id               string          `json:"id"`
+	ProjectId        string          `json:"project_id"`
+	Name             string          `json:"name"`
+	ArtifactLocation string          `json:"artifact_location"`
+	LifecycleStage   string          `json:"lifecycle_stage"`
+	LastUpdatedTime  int64           `json:"last_update_time"`
+	CreatedTime      int64           `json:"creation_time"`
+	Tags             []ExperimentTag `json:"tags"`
+}
+
+type PlatformExperimentListResponse struct {
+	Experiments   []PlatformExperiment `json:"experiments"`
+	NextPageToken string               `json:"next_page_token"`
+}
+
 type PlatformMLFlow struct {
 	MLFlow
 }
@@ -29,7 +45,7 @@ func NewPlatformMLFlow(baseUrl string, cfg *Config, connections *clientbase.Conn
 }
 
 func (m *PlatformMLFlow) UpdateRun(ctx context.Context, run *Run) error {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs/%s", m.baseUrl, m.cfg.CDSWProjectNum, run.Info.ExperimentId, run.Info.RunId)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs/%s", m.baseUrl, m.cfg.CDSWProjectID, run.Info.ExperimentId, run.Info.RunId)
 	req := cbhttp.NewRequest(ctx, "POST", url)
 
 	encoded, err := json.Marshal(run)
@@ -50,15 +66,15 @@ func (m *PlatformMLFlow) UpdateRun(ctx context.Context, run *Run) error {
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("failed to update run %s: %s", run.Info.RunId, resp.Status)
 	}
-	_, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return err
+	_, ioerr := io.ReadAll(resp.Body)
+	if ioerr != nil {
+		return ioerr
 	}
 	return nil
 }
 
 func (m *PlatformMLFlow) GetRun(ctx context.Context, experimentId string, runId string) (*Run, error) {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs/%s", m.baseUrl, m.cfg.CDSWProjectNum, experimentId, runId)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs/%s", m.baseUrl, m.cfg.CDSWProjectID, experimentId, runId)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 
 	req.Header = make(map[string][]string)
@@ -95,7 +111,7 @@ func (m *PlatformMLFlow) ListRuns(ctx context.Context, experimentId string) ([]*
 		if done {
 			break
 		}
-		url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs?page_token=%s", m.baseUrl, m.cfg.CDSWProjectNum, experimentId, token)
+		url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs?page_token=%s", m.baseUrl, m.cfg.CDSWProjectID, experimentId, token)
 		req := cbhttp.NewRequest(ctx, "GET", url)
 		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
@@ -135,16 +151,16 @@ func (m *PlatformMLFlow) ListRuns(ctx context.Context, experimentId string) ([]*
 }
 
 func (m *PlatformMLFlow) CreateRun(ctx context.Context, experimentId string, name string, createdTs time.Time, tags []RunTag) (string, error) {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs", m.baseUrl, m.cfg.CDSWProjectNum, experimentId)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs", m.baseUrl, m.cfg.CDSWProjectID, experimentId)
 	req := cbhttp.NewRequest(ctx, "POST", url)
 	body := map[string]interface{}{
-		"project_id":    m.cfg.CDSWProjectNum,
+		"project_id":    m.cfg.CDSWProjectID,
 		"experiment_id": experimentId,
 	}
-	encoded, err := json.Marshal(body)
-	if err != nil {
-		log.Printf("failed to encode body: %s", err)
-		return "", err
+	encoded, jerr := json.Marshal(body)
+	if jerr != nil {
+		log.Printf("failed to encode body: %s", jerr)
+		return "", jerr
 	}
 	req.Body = io.NopCloser(bytes.NewReader(encoded))
 	req.Header = make(map[string][]string)
@@ -161,24 +177,24 @@ func (m *PlatformMLFlow) CreateRun(ctx context.Context, experimentId string, nam
 		return "", fmt.Errorf("failed to create experiment %s: %s", name, resp.Status)
 	}
 	var run Run
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("failed to read body: %s", err)
-		return "", err
+	respBody, ioerr := io.ReadAll(resp.Body)
+	if ioerr != nil {
+		log.Printf("failed to read body: %s", ioerr)
+		return "", ioerr
 	}
-	err = json.Unmarshal(respBody, &run)
-	if err != nil {
-		log.Printf("failed to unmarshal body: %s", err)
-		return "", err
+	serr := json.Unmarshal(respBody, &run)
+	if serr != nil {
+		log.Printf("failed to unmarshal body: %s", serr)
+		return "", serr
 	}
 	return run.Info.RunId, nil
 }
 
 func (m *PlatformMLFlow) CreateExperiment(ctx context.Context, name string) (string, error) {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments", m.baseUrl, m.cfg.CDSWProjectNum)
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments", m.baseUrl, m.cfg.CDSWProjectID)
 	req := cbhttp.NewRequest(ctx, "POST", url)
 	body := map[string]interface{}{
-		"project_id": m.cfg.CDSWProjectNum,
+		"project_id": m.cfg.CDSWProjectID,
 		"name":       name,
 	}
 	encoded, err := json.Marshal(body)
@@ -190,10 +206,18 @@ func (m *PlatformMLFlow) CreateExperiment(ctx context.Context, name string) (str
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
-	resp, err := m.connections.HttpClient.Do(req)
-	if err != nil {
-		log.Printf("failed to create experiment %s: %s", name, err)
-		return "", err
+	resp, lerr := m.connections.HttpClient.Do(req)
+	if lerr != nil {
+		if lerr.Code == 409 {
+			experiment, gerr := m.GetExperimentByName(ctx, name)
+			if gerr != nil {
+				log.Printf("failed to fetch experiment %s: %s", name, gerr)
+				return "", gerr
+			}
+			return experiment.ExperimentId, nil
+		}
+		log.Printf("failed to create experiment %s: %s", name, lerr)
+		return "", lerr
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
@@ -201,16 +225,16 @@ func (m *PlatformMLFlow) CreateExperiment(ctx context.Context, name string) (str
 		return "", fmt.Errorf("failed to create experiment %s: %s", name, resp.Status)
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("failed to read body: %s", err)
-		return "", err
+	respBody, ioerr := io.ReadAll(resp.Body)
+	if ioerr != nil {
+		log.Printf("failed to read body: %s", ioerr)
+		return "", ioerr
 	}
 	var experiment Experiment
-	err = json.Unmarshal(respBody, &experiment)
-	if err != nil {
-		log.Printf("failed to unmarshal body: %s", err)
-		return "", err
+	serr := json.Unmarshal(respBody, &experiment)
+	if serr != nil {
+		log.Printf("failed to unmarshal body: %s", serr)
+		return "", serr
 	}
 	return experiment.ExperimentId, nil
 }
@@ -223,7 +247,7 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 		if done {
 			break
 		}
-		url := fmt.Sprintf("%s/api/v2/projects/%s/experiments?page_size=%d&page_token=%s", m.baseUrl, m.cfg.CDSWProjectNum, maxItems, token)
+		url := fmt.Sprintf("%s/api/v2/projects/%s/experiments?page_size=%d&page_token=%s", m.baseUrl, m.cfg.CDSWProjectID, maxItems, token)
 		req := cbhttp.NewRequest(ctx, "GET", url)
 		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
@@ -247,7 +271,7 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 			done = true
 			continue
 		}
-		var experimentsResponse ExperimentListResponse
+		var experimentsResponse PlatformExperimentListResponse
 		serr := json.Unmarshal(respBody, &experimentsResponse)
 		if serr != nil {
 			log.Printf("failed to unmarshal body: %s", serr)
@@ -255,7 +279,15 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 			continue
 		}
 		for _, experiment := range experimentsResponse.Experiments {
-			experiments = append(experiments, experiment)
+			experiments = append(experiments, &Experiment{
+				ExperimentId:     experiment.Id,
+				Name:             experiment.Name,
+				ArtifactLocation: experiment.ArtifactLocation,
+				LifecycleStage:   experiment.LifecycleStage,
+				LastUpdatedTime:  experiment.LastUpdatedTime,
+				CreatedTime:      experiment.CreatedTime,
+				Tags:             experiment.Tags,
+			})
 		}
 		if experimentsResponse.NextPageToken == "" {
 			done = true
@@ -266,8 +298,50 @@ func (m *PlatformMLFlow) ListExperiments(ctx context.Context, maxItems int64, pa
 	return experiments, nil
 }
 
+func (m *PlatformMLFlow) GetExperimentByName(ctx context.Context, name string) (*Experiment, error) {
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments", m.baseUrl, m.cfg.CDSWProjectID) // TODO figure out search_filter parameter
+	req := cbhttp.NewRequest(ctx, "GET", url)
+	req.Header = make(map[string][]string)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("authorization", fmt.Sprintf("Bearer %s", m.cfg.CDSWApiKey))
+	resp, err := m.connections.HttpClient.Do(req)
+	if err != nil {
+		log.Printf("failed to fetch experiment %s: %s", name, err)
+		return nil, err
+	}
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	body, ioerr := io.ReadAll(resp.Body)
+	if ioerr != nil {
+		return nil, err
+	}
+	var experimentListResponse PlatformExperimentListResponse
+	jerr := json.Unmarshal(body, &experimentListResponse)
+	if jerr != nil {
+		return nil, err
+	}
+	for _, experiment := range experimentListResponse.Experiments {
+		if experiment.Name == name {
+			return &Experiment{
+				ExperimentId:     experiment.Id,
+				Name:             experiment.Name,
+				ArtifactLocation: experiment.ArtifactLocation,
+				LifecycleStage:   experiment.LifecycleStage,
+				LastUpdatedTime:  experiment.LastUpdatedTime,
+				CreatedTime:      experiment.CreatedTime,
+				Tags:             experiment.Tags,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
 func (m *PlatformMLFlow) GetExperiment(ctx context.Context, experimentId string) (*Experiment, error) {
-	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/get?experiment_id=%s", m.baseUrl, m.cfg.CDSWProjectNum, experimentId)
+	log.Printf("fetching experiment %s, id length is %d runes", experimentId, len(experimentId))
+	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s", m.baseUrl, m.cfg.CDSWProjectID, experimentId)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	req.Header = make(map[string][]string)
 	req.Header.Set("Content-Type", "application/json")

--- a/api/internal/db/sqlite/metrics.go
+++ b/api/internal/db/sqlite/metrics.go
@@ -42,7 +42,7 @@ func (r *Metrics) CreateMetric(ctx context.Context, m *db.Metric) (*db.Metric, e
 				}
 			}
 			if tagsMatch {
-				log.Printf("Metric %s already exists for experiment %s and run %s : %d", m.Name, m.ExperimentId, m.RunId, existingMetric.Id)
+				log.Debugf("Metric %s already exists for experiment %s and run %s : %d", m.Name, m.ExperimentId, m.RunId, existingMetric.Id)
 				return existingMetric, nil
 			}
 		}

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -39,7 +39,7 @@ func (r *ExperimentReconciler) Resync(ctx context.Context, queue *reconciler.Rec
 		queue.Add(ex.ExperimentId)
 	}
 
-	log.Printf("queueing %d experiments for reconciliation", len(experiments))
+	log.Printf("queueing %d local experiments for reconciliation", len(experiments))
 
 	log.Debugln("completing reconciler resync")
 }

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -33,6 +33,9 @@ func (r *ExperimentReconciler) Resync(ctx context.Context, queue *reconciler.Rec
 		log.Printf("failed to fetch experiments from local mlflow: %s", err)
 	}
 	for _, ex := range experiments {
+		if ex.Name == "" || ex.Name == "Default" {
+			continue
+		}
 		queue.Add(ex.ExperimentId)
 	}
 

--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -59,7 +59,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 
 		if experiment.RemoteExperimentId == "" {
 			// If the experiment does not exist in the remote store, insert it
-			log.Printf("experiment %s not found in remote store, inserting", experiment.ExperimentId)
+			log.Printf("experiment %s has no remote experiment ID, inserting into the remote MLFLow instance", experiment.ExperimentId)
 			remoteExperimentId, err := r.dataStores.Remote.CreateExperiment(ctx, local.Name)
 			if err != nil {
 				log.Printf("failed to insert experiment %d into remote store: %s", item.ID, err)

--- a/api/internal/reconcilers/reconcilers.go
+++ b/api/internal/reconcilers/reconcilers.go
@@ -56,14 +56,14 @@ func NewReconcilerSet(app *app.Instance, experimentsCfg *experiments.Config, exp
 
 func (r *ReconcilerSet) Start() {
 	r.experimentManager.Start()
-	//r.syncManager.Start()
+	r.syncManager.Start()
 	//r.runManager.Start()
 	r.metricsManager.Start()
 }
 
 func (r *ReconcilerSet) Finish() {
 	r.experimentManager.Finish()
-	//r.syncManager.Finish()
+	r.syncManager.Finish()
 	//r.runManager.Finish()
 	r.metricsManager.Finish()
 }

--- a/local.sh
+++ b/local.sh
@@ -3,6 +3,21 @@ set -eo pipefail
 
 CDSW_APP_PORT=${CDSW_APP_PORT:-8100}
 
+if [ -z "$CDSW_API_URL" ] ; then
+  echo "CDSW_API_URL"
+  exit 1
+fi
+
+if [ -z "$CDSW_PROJECT_NUM" ] ; then
+  echo "CDSW_PROJECT_NUM must be set"
+  exit 1
+fi
+
+if [ -z "$CDSW_API_KEY" ] ; then
+  echo "CDSW_API_KEY must be set"
+  exit 1
+fi
+
 if [ -z "$AWS_REGION" ] && [ -z "$CAII_DOMAIN" ]; then
   echo "Either AWS_REGION or CAII_DOMAIN must be set"
   exit 1
@@ -27,4 +42,4 @@ if [ -n "$CAII_DOMAIN" ]; then
 fi
 
 docker build --platform=linux/amd64 -t ragmon:latest .
-docker run --platform=linux/amd64 -it --rm $DOCKER_CMD_ENV -e LOCAL=true -e ADDRESS=0.0.0.0 -e CDSW_APP_PORT=$CDSW_APP_PORT -p $CDSW_APP_PORT:$CDSW_APP_PORT ragmon:latest
+docker run --platform=linux/amd64 -it --rm "$DOCKER_CMD_ENV" -e LOCAL=true -e ADDRESS=0.0.0.0 -e CDSW_API_URL="$CDSW_API_URL" -e CDSW_PROJECT_NUM="$CDSW_PROJECT_NUM" -e CDSW_APP_PORT="$CDSW_APP_PORT" -p "$CDSW_APP_PORT":"$CDSW_APP_PORT" ragmon:latest

--- a/local.sh
+++ b/local.sh
@@ -8,8 +8,8 @@ if [ -z "$CDSW_API_URL" ] ; then
   exit 1
 fi
 
-if [ -z "$CDSW_PROJECT_NUM" ] ; then
-  echo "CDSW_PROJECT_NUM must be set"
+if [ -z "$CDSW_PROJECT_ID" ] ; then
+  echo "CDSW_PROJECT_ID must be set"
   exit 1
 fi
 
@@ -42,4 +42,4 @@ if [ -n "$CAII_DOMAIN" ]; then
 fi
 
 docker build --platform=linux/amd64 -t ragmon:latest .
-docker run --platform=linux/amd64 -it --rm "$DOCKER_CMD_ENV" -e LOCAL=true -e ADDRESS=0.0.0.0 -e CDSW_API_URL="$CDSW_API_URL" -e CDSW_PROJECT_NUM="$CDSW_PROJECT_NUM" -e CDSW_APP_PORT="$CDSW_APP_PORT" -p "$CDSW_APP_PORT":"$CDSW_APP_PORT" ragmon:latest
+docker run --platform=linux/amd64 -it --rm "$DOCKER_CMD_ENV" -e LOCAL=true -e ADDRESS=0.0.0.0 -e CDSW_API_URL="$CDSW_API_URL" -e CDSW_PROJECT_ID="$CDSW_PROJECT_ID" -e CDSW_APP_PORT="$CDSW_APP_PORT" -p "$CDSW_APP_PORT":"$CDSW_APP_PORT" ragmon:latest


### PR DESCRIPTION
The sync reconciler reads updated experiment rows from the DB and queries MLFlow for experiment data, which is then sync'ed to the remote platform MLFlow instance.

Adds three new required env vars needed to communicate with the CML REST API:
- CDSW_PROJECT_ID
- CDSW_API_URL
- CDSW_API_KEY