### PR TITLE
Feature: Enable the experiment run synchronization reconciler

### DIFF
--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -29,12 +29,11 @@ func NewMLFlow(baseUrl string, cfg *Config, connections *clientbase.Connections)
 }
 
 func (m *MLFlow) UpdateRun(ctx context.Context, run *Run) error {
-	//TODO implement me
-	panic("implement me")
+	panic("local mlflow UpdateRun is not supported")
 }
 
 func (m *MLFlow) GetRun(ctx context.Context, experimentId string, runId string) (*Run, error) {
-	url := fmt.Sprintf("%s/api/2.0/mlflow/get?run_id=%s", m.baseUrl, runId)
+	url := fmt.Sprintf("%s/api/2.0/mlflow/runs/get?run_id=%s", m.baseUrl, runId)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {

--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/datasource"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/db"
+	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/util"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/pkg/app"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/pkg/reconciler"
 	"time"
@@ -116,7 +117,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 				continue
 			}
 			// Insert the run into the remote store
-			remoteRunId, err := r.dataStores.Remote.CreateRun(ctx, experiment.RemoteExperimentId, run.Info.Name, ts(run.Info.StartTime), run.Data.Tags)
+			remoteRunId, err := r.dataStores.Remote.CreateRun(ctx, experiment.RemoteExperimentId, run.Info.Name, util.TimeStamp(run.Info.StartTime), run.Data.Tags)
 			if err != nil {
 				log.Printf("failed to insert run %s into remote store: %s", run.Info.Name, err)
 				continue
@@ -140,7 +141,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 		}
 
 		// Update the flag and timestamp of the experiment to indicate that it has finished reconciliation
-		err = r.db.Experiments().UpdateExperimentUpdatedAndTimestamp(ctx, experiment.Id, false, ts(local.LastUpdatedTime))
+		err = r.db.Experiments().UpdateExperimentUpdatedAndTimestamp(ctx, experiment.Id, false, util.TimeStamp(local.LastUpdatedTime))
 		if err != nil {
 			log.Printf("failed to update experiment %d timestamp: %s", item.ID, err)
 		}

--- a/api/internal/reconcilers/reconcilers.go
+++ b/api/internal/reconcilers/reconcilers.go
@@ -57,13 +57,13 @@ func NewReconcilerSet(app *app.Instance, experimentsCfg *experiments.Config, exp
 func (r *ReconcilerSet) Start() {
 	r.experimentManager.Start()
 	r.syncManager.Start()
-	//r.runManager.Start()
+	r.runManager.Start()
 	r.metricsManager.Start()
 }
 
 func (r *ReconcilerSet) Finish() {
 	r.experimentManager.Finish()
 	r.syncManager.Finish()
-	//r.runManager.Finish()
+	r.runManager.Finish()
 	r.metricsManager.Finish()
 }

--- a/api/internal/util/time.go
+++ b/api/internal/util/time.go
@@ -1,0 +1,9 @@
+package util
+
+import "time"
+
+func TimeStamp(millis int64) time.Time {
+	seconds := millis / 1000
+	nanoseconds := (millis % 1000) * 1e6
+	return time.Unix(seconds, nanoseconds)
+}


### PR DESCRIPTION
Fetches experiment runs from local MLFlow and syncs them to the platform.

Note: due to platform limitations, run parameter values must be truncated to 250 characters.