### PR TITLE
fix: check for an existing run in the db before inserting

### DIFF
--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -81,10 +81,10 @@ func (m *MLFlow) ListRuns(ctx context.Context, experimentId string) ([]*Run, err
 		req.Body = io.NopCloser(bytes.NewReader(encoded))
 		req.Header = make(map[string][]string)
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := m.connections.HttpClient.Do(req)
-		if err != nil {
-			log.Printf("failed to fetch runs for experiment %s: %s", experimentId, err)
-			return nil, err
+		resp, lerr := m.connections.HttpClient.Do(req)
+		if lerr != nil {
+			log.Printf("failed to fetch runs for experiment %s: %s", experimentId, lerr)
+			return nil, lerr
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {

--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -2,6 +2,8 @@ package experiments
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	log "github.com/sirupsen/logrus"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/datasource"
 	"github.infra.cloudera.com/CAI/AmpRagMonitoring/internal/db"
@@ -122,21 +124,33 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 				log.Printf("failed to insert run %s into remote store: %s", run.Info.Name, err)
 				continue
 			}
-			// Insert the run into the DB
-			newRun, err := r.db.ExperimentRuns().CreateExperimentRun(ctx, &db.ExperimentRun{
-				Id:           0,
-				ExperimentId: run.Info.ExperimentId,
-				RunId:        run.Info.RunId,
-				RemoteRunId:  remoteRunId,
-			})
-			if err != nil {
-				log.Printf("failed to insert run %s into DB: %s", run.Info.Name, err)
+			// Check and see if the run already exists in the DB and insert it if not
+			existing, dberr := r.db.ExperimentRuns().GetExperimentRun(ctx, experiment.ExperimentId, run.Info.RunId)
+			if dberr != nil && !errors.Is(dberr, sql.ErrNoRows) {
+				log.Printf("failed to fetch run %s from DB: %s", run.Info.Name, dberr)
 				continue
 			}
+			var id int64
+			if existing != nil {
+				id = existing.Id
+			} else {
+				// Insert the run into the DB
+				newRun, dberr := r.db.ExperimentRuns().CreateExperimentRun(ctx, &db.ExperimentRun{
+					Id:           0,
+					ExperimentId: run.Info.ExperimentId,
+					RunId:        run.Info.RunId,
+					RemoteRunId:  remoteRunId,
+				})
+				if dberr != nil {
+					log.Printf("failed to insert run %s into DB: %s", run.Info.Name, dberr)
+					continue
+				}
+				id = newRun.Id
+			}
 			// Flag the run as ready for reconciliation
-			err = r.db.ExperimentRuns().UpdateExperimentRunUpdatedAndTimestamp(ctx, newRun.Id, true, time.Now())
+			err = r.db.ExperimentRuns().UpdateExperimentRunUpdatedAndTimestamp(ctx, id, true, time.Now())
 			if err != nil {
-				log.Printf("failed to update run %d timestamp: %s", newRun.Id, err)
+				log.Printf("failed to update run %d timestamp: %s", id, err)
 			}
 		}
 

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -48,6 +48,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.Reconcile
 		run, err := r.db.ExperimentRuns().GetExperimentRunById(ctx, item.ID)
 		if err != nil {
 			log.Printf("failed to fetch experiment run %d for reconciliation: %s", item.ID, err)
+			continue
 		}
 		// Fetch metrics from MLFlow
 		mlFlowMetrics, err := r.mlFlow.Local.Metrics(ctx, run.RunId)


### PR DESCRIPTION
Fix a bug where a duplicate key error could occur if the run row already existed due to a failed reconciler run.

This prevent the metrics reconciler from running successfully when it occured.