### PR TITLE
Refactor: Build the CDSW base url from the domain and protocol.

### DIFF
--- a/api/internal/datasource/config.go
+++ b/api/internal/datasource/config.go
@@ -8,6 +8,8 @@ import (
 
 type Config struct {
 	LocalMLFlowBaseUrl string `env:"LOCAL_MLFLOW_BASE_URL" envDefault:"http://localhost:5000"`
+	CDSWDomain         string `env:"CDSW_DOMAIN" envDefault:""`
+	CDSWApiProtocol    string `env:"CDSW_API_PROTOCOL" envDefault:"https"`
 	CDSWMLFlowBaseUrl  string `env:"CDSW_API_URL" envDefault:""`
 	CDSWProjectID      string `env:"CDSW_PROJECT_ID" envDefault:""`
 	CDSWApiKey         string `env:"CDSW_APIV2_KEY" envDefault:""`
@@ -20,8 +22,11 @@ func NewConfigFromEnv() (*Config, error) {
 		return nil, err
 	}
 
+	if cfg.CDSWMLFlowBaseUrl == "" && cfg.CDSWDomain == "" {
+		return nil, errors.New("one of CDSWDomain or CDSW_API_URL is required")
+	}
 	if cfg.CDSWMLFlowBaseUrl == "" {
-		return nil, errors.New("CDSW_API_URL is required")
+		cfg.CDSWMLFlowBaseUrl = cfg.CDSWApiProtocol + "://" + cfg.CDSWDomain
 	}
 	if cfg.CDSWProjectID == "" {
 		return nil, errors.New("CDSW_PROJECT_ID is required")
@@ -29,8 +34,8 @@ func NewConfigFromEnv() (*Config, error) {
 	if cfg.CDSWApiKey == "" {
 		return nil, errors.New("CDSW_APIV2_KEY is required")
 	}
-	log.Printf("CDSW_API_URL: %s", cfg.CDSWMLFlowBaseUrl)
-	log.Printf("CDSW_PROJECT_ID: %s", cfg.CDSWProjectID)
-	log.Printf("CDSW_APIV2_KEY: %d tokens", len(cfg.CDSWApiKey))
+	log.Printf("CDSW base url: %s", cfg.CDSWMLFlowBaseUrl)
+	log.Printf("CDSW project ID: %s", cfg.CDSWProjectID)
+	log.Printf("CDSW api key is %d tokens in length", len(cfg.CDSWApiKey))
 	return &cfg, nil
 }


### PR DESCRIPTION
The CDSW_API_URL present inside an AMP is a v1 url, but the API requires v2.  