### PR TITLE
fix: add a missing sql param to the list runs query

### DIFF
--- a/api/internal/db/sqlite/experiment-runs.go
+++ b/api/internal/db/sqlite/experiment-runs.go
@@ -69,7 +69,7 @@ func (e *ExperimentRuns) GetExperimentRun(ctx context.Context, experimentId stri
 
 func (e *ExperimentRuns) ListExperimentRuns(ctx context.Context, experimentId string) ([]*db.ExperimentRun, error) {
 	query := `
-	SELECT id, experiment_id, run_id, created, updated, deleted, created_ts, updated_ts
+	SELECT id, experiment_id, run_id, remote_run_id, created, updated, deleted, created_ts, updated_ts
 	FROM experiment_runs
 	WHERE experiment_id = ?
 	`


### PR DESCRIPTION
The query was missing the remote_run_id field