### PR TITLE
fix: disable the creation of a run when the deprecated POST handler is invoked.

### DIFF
--- a/api/internal/restapi/experiment-runs-api.go
+++ b/api/internal/restapi/experiment-runs-api.go
@@ -42,6 +42,7 @@ func (e ExperimentRunsAPI) PostRunsList(ctx context.Context, params runs.PostRun
 }
 
 func (e ExperimentRunsAPI) PostRuns(ctx context.Context, params runs.PostRunsParams) (*runs.PostRunsOK, *lhttp.HttpError) {
+	log.Debugf("deprecated POST handler to register an experiment run invoked.")
 	if params.Body == nil {
 		return nil, lhttp.NewBadRequest("body is required")
 	}
@@ -51,18 +52,14 @@ func (e ExperimentRunsAPI) PostRuns(ctx context.Context, params runs.PostRunsPar
 	if params.Body.ExperimentRunID == "" {
 		return nil, lhttp.NewBadRequest("experiment_run_id is required")
 	}
-	log.Printf("Creating experiment run %s for experiment %s", params.Body.ExperimentRunID, params.Body.ExperimentID)
-	run, err := e.db.ExperimentRuns().CreateExperimentRun(ctx, &db.ExperimentRun{
-		ExperimentId: params.Body.ExperimentID,
-		RunId:        params.Body.ExperimentRunID,
-	})
+	run, err := e.db.ExperimentRuns().GetExperimentRun(ctx, params.Body.ExperimentID, params.Body.ExperimentRunID)
 	if err != nil {
 		return nil, lhttp.NewInternalError(err.Error())
 	}
 	return &runs.PostRunsOK{
 		Payload: &models.ExperimentRun{
-			ExperimentID:    run.ExperimentId,
-			ExperimentRunID: run.RunId,
+			ExperimentID:    params.Body.ExperimentID,
+			ExperimentRunID: params.Body.ExperimentRunID,
 			ID:              run.Id,
 		},
 	}, nil


### PR DESCRIPTION
Return the run created from the reconciler instead.