### PR TITLE
fix: do not reconcile nil experiments

### DIFF
--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -49,7 +49,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 			log.Printf("failed to fetch experiment %d for reconciliation: %s", item.ID, err)
 		}
 
-		if experiment.ExperimentId == "" || experiment.ExperimentId == "0" {
+		if experiment == nil || experiment.ExperimentId == "" || experiment.ExperimentId == "0" {
 			continue
 		}
 


### PR DESCRIPTION
prevents a segfault resulting from a nil pointer