### PR TITLE
fix: set the correct reconciler flag when metric reconciliation completes

### DIFF
--- a/api/internal/reconcilers/runs/runs_reconciler.go
+++ b/api/internal/reconcilers/runs/runs_reconciler.go
@@ -36,8 +36,9 @@ func (r *RunReconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQ
 		queue.Add(id)
 	}
 
-	log.Println(fmt.Sprintf("queueing %d runs for reconciliation", len(ids)))
-
+	if len(ids) > 0 {
+		log.Println(fmt.Sprintf("queueing %d runs for reconciliation", len(ids)))
+	}
 	log.Debugln("completing reconciler resync")
 }
 


### PR DESCRIPTION
- Adds details to logs about reconciler behavior
- Demotes chatty logging of empty reconciler queues