### PR TITLE
fix: apply the run info from the local run to the remote run when updating.

### DIFF
--- a/api/internal/datasource/platform_mlflow.go
+++ b/api/internal/datasource/platform_mlflow.go
@@ -33,7 +33,7 @@ type PlatformExperimentListResponse struct {
 type PlatformRun struct {
 	Id             string          `json:"id"`
 	Name           string          `json:"run_name"`
-	Status         RunStatus       `json:"status"`
+	Status         string          `json:"status"`
 	StartTime      time.Time       `json:"start_time"`
 	EndTime        time.Time       `json:"end_time"`
 	ArtifactUri    string          `json:"artifact_uri"`
@@ -102,10 +102,24 @@ func (m *PlatformMLFlow) UpdateRun(ctx context.Context, run *Run) error {
 		})
 	}
 
+	var status string
+	switch run.Info.Status {
+	case RunStatusRunning:
+		status = "EXPERIMENT_RUN_RUNNING"
+	case RunStatusScheduled:
+		status = "EXPERIMENT_RUN_SCHEDULED"
+	case RunStatusFinished:
+		status = "EXPERIMENT_RUN_FINISHED"
+	case RunStatusFailed:
+		status = "EXPERIMENT_RUN_FAILED"
+	case RunStatusKilled:
+		status = "EXPERIMENT_RUN_KILLED"
+	}
+
 	platformRun := PlatformRun{
 		Id:             run.Info.RunId,
 		Name:           run.Info.Name,
-		Status:         run.Info.Status,
+		Status:         status,
 		StartTime:      time.Unix(run.Info.StartTime, 0),
 		EndTime:        time.Unix(run.Info.EndTime, 0),
 		ArtifactUri:    run.Info.ArtifactUri,
@@ -188,7 +202,7 @@ func (m *PlatformMLFlow) GetRun(ctx context.Context, experimentId string, runId 
 			RunId:          runId,
 			Name:           run.Name,
 			ExperimentId:   experimentId,
-			Status:         run.Status,
+			Status:         RunStatus(run.Status),
 			StartTime:      run.StartTime.Unix(),
 			EndTime:        run.EndTime.Unix(),
 			ArtifactUri:    run.ArtifactUri,

--- a/api/internal/reconcilers/runs/runs_reconciler.go
+++ b/api/internal/reconcilers/runs/runs_reconciler.go
@@ -96,6 +96,11 @@ func (r *RunReconciler) Reconcile(ctx context.Context, items []reconciler.Reconc
 		}
 		log.Printf("syncing data for run %s to remote store", run.RunId)
 		// Sync the metrics to the remote store
+		remoteRun.Info.Name = localRun.Info.Name
+		remoteRun.Info.Status = localRun.Info.Status
+		remoteRun.Info.StartTime = util.TimeStamp(localRun.Info.StartTime).Unix()
+		remoteRun.Info.EndTime = util.TimeStamp(localRun.Info.EndTime).Unix()
+		remoteRun.Info.LifecycleStage = localRun.Info.LifecycleStage
 		remoteRun.Data = localRun.Data
 		err = r.dataStores.Remote.UpdateRun(ctx, remoteRun)
 		if err != nil {


### PR DESCRIPTION
Syncs:
- Name
- Status
- Start/End time
- Lifecycle stage