### PR TITLE
fix: wait for mlflow to be ready

### DIFF
--- a/api/cmd/api.go
+++ b/api/cmd/api.go
@@ -79,6 +79,12 @@ func main() {
 		panic(err)
 	}
 
+	// wait for the local mlflow instance to start
+	localErr := deps.dataStores.Local.WaitForReady(deps.app.Context())
+	if localErr != nil {
+		panic(localErr)
+	}
+
 	// Start the metrics reconciler
 	deps.reconcilers.Start()
 	defer deps.reconcilers.Finish()

--- a/api/internal/datasource/config.go
+++ b/api/internal/datasource/config.go
@@ -36,6 +36,5 @@ func NewConfigFromEnv() (*Config, error) {
 	}
 	log.Printf("CDSW base url: %s", cfg.CDSWMLFlowBaseUrl)
 	log.Printf("CDSW project ID: %s", cfg.CDSWProjectID)
-	log.Printf("CDSW api key is %d tokens in length", len(cfg.CDSWApiKey))
 	return &cfg, nil
 }

--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -40,12 +40,14 @@ func (m *MLFlow) WaitForReady(ctx context.Context) error {
 		if done {
 			break
 		}
-		_, err := m.ListExperiments(ctx, 1, "")
+		experiments, err := m.ListExperiments(ctx, 1, "")
 		if err != nil {
 			time.Sleep(1 * time.Second)
 		} else {
-			log.Println("mlflow is ready")
-			done = true
+			if len(experiments) > 0 {
+				log.Println("mlflow is ready")
+				done = true
+			}
 		}
 	}
 	return nil

--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -28,6 +28,29 @@ func NewMLFlow(baseUrl string, cfg *Config, connections *clientbase.Connections)
 	}
 }
 
+func (m *MLFlow) WaitForReady(ctx context.Context) error {
+	log.Println("waiting for mlflow to be ready")
+	done := false
+	iterations := 0
+	for {
+		iterations++
+		if iterations%10 == 0 {
+			log.Printf("(%ds) waiting for mlflow to be ready", iterations)
+		}
+		if done {
+			break
+		}
+		_, err := m.ListExperiments(ctx, 1, "")
+		if err != nil {
+			time.Sleep(1 * time.Second)
+		} else {
+			log.Println("mlflow is ready")
+			done = true
+		}
+	}
+	return nil
+}
+
 func (m *MLFlow) UpdateRun(ctx context.Context, run *Run) (*Run, error) {
 	panic("local mlflow UpdateRun is not supported")
 }
@@ -37,7 +60,7 @@ func (m *MLFlow) GetRun(ctx context.Context, experimentId string, runId string) 
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("failed to fetch run %s: %s", runId, err)
+		log.Debugf("failed to fetch run %s: %s", runId, err)
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
@@ -75,7 +98,7 @@ func (m *MLFlow) ListRuns(ctx context.Context, experimentId string) ([]*Run, err
 		}
 		encoded, serr := json.Marshal(body)
 		if serr != nil {
-			log.Printf("failed to encode body: %s", serr)
+			log.Debugf("failed to encode body: %s", serr)
 			return nil, serr
 		}
 		req.Body = io.NopCloser(bytes.NewReader(encoded))
@@ -83,24 +106,24 @@ func (m *MLFlow) ListRuns(ctx context.Context, experimentId string) ([]*Run, err
 		req.Header.Set("Content-Type", "application/json")
 		resp, lerr := m.connections.HttpClient.Do(req)
 		if lerr != nil {
-			log.Printf("failed to fetch runs for experiment %s: %s", experimentId, lerr)
+			log.Debugf("failed to fetch runs for experiment %s: %s", experimentId, lerr)
 			return nil, lerr
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
-			log.Printf("failed to fetch runs: %s", resp.Status)
+			log.Debugf("failed to fetch runs: %s", resp.Status)
 			return nil, fmt.Errorf("failed to fetch runs for experiment %s: %s", experimentId, resp.Status)
 		}
 
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Printf("failed to read body: %s", err)
+			log.Debugf("failed to read body: %s", err)
 			return nil, err
 		}
 		var runsResponse RunsResponse
 		err = json.Unmarshal(respBody, &runsResponse)
 		if err != nil {
-			log.Printf("failed to unmarshal body: %s", err)
+			log.Debugf("failed to unmarshal body: %s", err)
 			return nil, err
 		}
 		for _, run := range runsResponse.Runs {
@@ -129,11 +152,11 @@ func (m *MLFlow) Metrics(ctx context.Context, experimentId string, runId string)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("failed to fetch metrics for run %s: %s", runId, err)
+		log.Debugf("failed to fetch metrics for run %s: %s", runId, err)
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
-		log.Printf("metrics not found for run %s", runId)
+		log.Debugf("metrics not found for run %s", runId)
 		return []Metric{}, nil
 	}
 	defer resp.Body.Close()
@@ -159,15 +182,15 @@ func (m *MLFlow) Artifacts(ctx context.Context, runId string, path *string) ([]A
 	if path != nil {
 		url = fmt.Sprintf("%s&path=%s", url, *path)
 	}
-	log.Printf("fetching artifacts for run %s using url %s", runId, url)
+	log.Debugf("fetching artifacts for run %s using url %s", runId, url)
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
 		if err.Code == 404 {
-			log.Printf("run %s has no artifacts", runId)
+			log.Debugf("run %s has no artifacts", runId)
 			return []Artifact{}, nil
 		}
-		log.Printf("failed to fetch artifacts for run %s: %s", runId, err)
+		log.Debugf("failed to fetch artifacts for run %s: %s", runId, err)
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
@@ -196,7 +219,7 @@ func (m *MLFlow) GetArtifact(ctx context.Context, runId string, path string) ([]
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("failed to fetch arrtifacts for run %s: %s", runId, err)
+		log.Debugf("failed to fetch arrtifacts for run %s: %s", runId, err)
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
@@ -225,31 +248,31 @@ func (m *MLFlow) CreateExperiment(ctx context.Context, name string) (string, err
 	}
 	encoded, err := json.Marshal(body)
 	if err != nil {
-		log.Printf("failed to encode body: %s", err)
+		log.Debugf("failed to encode body: %s", err)
 		return "", err
 	}
 	req.Body = io.NopCloser(bytes.NewReader(encoded))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("failed to create experiment %s: %s", name, err)
+		log.Debugf("failed to create experiment %s: %s", name, err)
 		return "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		log.Printf("failed to fetch experiments: %s", resp.Status)
+		log.Debugf("failed to fetch experiments: %s", resp.Status)
 		return "", fmt.Errorf("failed to create experiment %s: %s", name, resp.Status)
 	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("failed to read body: %s", err)
+		log.Debugf("failed to read body: %s", err)
 		return "", err
 	}
 	var experiment Experiment
 	err = json.Unmarshal(respBody, &experiment)
 	if err != nil {
-		log.Printf("failed to unmarshal body: %s", err)
+		log.Debugf("failed to unmarshal body: %s", err)
 		return "", err
 	}
 	return experiment.ExperimentId, nil
@@ -271,7 +294,7 @@ func (m *MLFlow) ListExperiments(ctx context.Context, maxItems int64, pageToken 
 
 		encoded, err := json.Marshal(body)
 		if err != nil {
-			log.Printf("failed to encode body: %s", err)
+			log.Debugf("failed to encode body: %s", err)
 		}
 		req := cbhttp.NewRequest(ctx, "POST", url)
 		req.Body = io.NopCloser(bytes.NewReader(encoded))
@@ -281,7 +304,7 @@ func (m *MLFlow) ListExperiments(ctx context.Context, maxItems int64, pageToken 
 
 		if lerr != nil {
 			if lerr.Code != 404 {
-				log.Errorf("failed to fetch local experiments: %s", lerr)
+				log.Debugf("failed to fetch local experiments: %s", lerr)
 			}
 			done = true
 			continue
@@ -290,7 +313,7 @@ func (m *MLFlow) ListExperiments(ctx context.Context, maxItems int64, pageToken 
 
 		if resp.StatusCode != 200 {
 			if resp.StatusCode != 404 {
-				log.Printf("failed to fetch experiments: %s", err)
+				log.Debugf("failed to fetch experiments: %s", err)
 			}
 			done = true
 			continue
@@ -298,14 +321,14 @@ func (m *MLFlow) ListExperiments(ctx context.Context, maxItems int64, pageToken 
 
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Printf("failed to read body: %s", err)
+			log.Debugf("failed to read body: %s", err)
 			done = true
 			continue
 		}
 		var experimentsResponse ExperimentListResponse
 		err = json.Unmarshal(respBody, &experimentsResponse)
 		if err != nil {
-			log.Printf("failed to unmarshal body: %s", err)
+			log.Debugf("failed to unmarshal body: %s", err)
 			done = true
 			continue
 		}
@@ -326,7 +349,6 @@ func (m *MLFlow) GetExperiment(ctx context.Context, experimentId string) (*Exper
 	req := cbhttp.NewRequest(ctx, "GET", url)
 	resp, err := m.connections.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("failed to fetch experiment %s: %s", experimentId, err)
 		return nil, err
 	}
 	if resp.StatusCode == 404 {

--- a/api/internal/datasource/mlflow.go
+++ b/api/internal/datasource/mlflow.go
@@ -31,12 +31,7 @@ func NewMLFlow(baseUrl string, cfg *Config, connections *clientbase.Connections)
 func (m *MLFlow) WaitForReady(ctx context.Context) error {
 	log.Println("waiting for mlflow to be ready")
 	done := false
-	iterations := 0
 	for {
-		iterations++
-		if iterations%10 == 0 {
-			log.Printf("(%ds) waiting for mlflow to be ready", iterations)
-		}
 		if done {
 			break
 		}

--- a/api/internal/datasource/platform_mlflow.go
+++ b/api/internal/datasource/platform_mlflow.go
@@ -122,6 +122,10 @@ func NewPlatformMLFlow(baseUrl string, cfg *Config, connections *clientbase.Conn
 	}
 }
 
+func (m *PlatformMLFlow) WaitForReady(ctx context.Context) error {
+	return nil
+}
+
 func (m *PlatformMLFlow) UpdateRun(ctx context.Context, run *Run) (*Run, error) {
 	url := fmt.Sprintf("%s/api/v2/projects/%s/experiments/%s/runs/%s", m.baseUrl, m.cfg.CDSWProjectID, run.Info.ExperimentId, run.Info.RunId)
 	req := cbhttp.NewRequest(ctx, "PATCH", url)

--- a/api/internal/datasource/store.go
+++ b/api/internal/datasource/store.go
@@ -34,6 +34,7 @@ type DataStore interface {
 	ArtifactStore
 	ExperimentStore
 	RunStore
+	WaitForReady(ctx context.Context) error
 }
 
 type DataStores struct {

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -50,7 +50,7 @@ func (r *ExperimentReconciler) Resync(ctx context.Context, queue *reconciler.Rec
 	}
 
 	if queued > 0 {
-		log.Debugf("queueing %d local experiments for reconciliation", queued)
+		log.Printf("queueing %d local experiments for reconciliation", queued)
 	}
 
 	log.Debugln("completing reconciler resync")

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -108,7 +108,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, items []reconciler
 			log.Printf("failed to update experiment %s with ID %s timestamp: %s", local.Name, item.ID, err)
 		}
 
-		log.Printf("finished reconciling experiment %s with ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
+		log.Debugf("finished reconciling experiment %s with ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
 	}
 }
 

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -57,6 +57,7 @@ func (r *ExperimentReconciler) Resync(ctx context.Context, queue *reconciler.Rec
 }
 
 func (r *ExperimentReconciler) Reconcile(ctx context.Context, items []reconciler.ReconcileItem[string]) {
+	log.Printf("reconciling %d local experiments", len(items))
 	for _, item := range items {
 		// Fetch the experiment MLFlow
 		local, err := r.dataStores.Local.GetExperiment(ctx, item.ID)

--- a/api/internal/reconcilers/experiments/experiment_reconciler.go
+++ b/api/internal/reconcilers/experiments/experiment_reconciler.go
@@ -108,7 +108,7 @@ func (r *ExperimentReconciler) Reconcile(ctx context.Context, items []reconciler
 			log.Printf("failed to update experiment %s with ID %s timestamp: %s", local.Name, item.ID, err)
 		}
 
-		log.Printf("finished reconciling experiment %s with ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
+		log.Debugf("finished reconciling experiment %s with ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
 	}
 }
 
@@ -131,5 +131,5 @@ func NewExperimentReconciler(config *Config, db db.Database, dataStores datasour
 }
 
 func (r *ExperimentReconciler) Name() string {
-	return "mlflow-experiment-reconciler"
+	return "experiment-reconciler"
 }

--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -25,7 +25,7 @@ func (r *SyncReconciler) Resync(ctx context.Context, queue *reconciler.Reconcile
 	if !r.config.Enabled {
 		return
 	}
-	log.Debugln("beginning experiments reconciler resync")
+	log.Println("beginning experiment sync reconciler resync")
 
 	maxItems := int64(r.config.ResyncMaxItems)
 
@@ -38,7 +38,7 @@ func (r *SyncReconciler) Resync(ctx context.Context, queue *reconciler.Reconcile
 	}
 
 	if len(ids) > 0 {
-		log.Debugf("queueing %d experiments for sync reconciliation", len(ids))
+		log.Printf("queueing %d experiments for sync reconciliation", len(ids))
 	}
 	log.Debugln("completing mlflow sync reconciler resync")
 }
@@ -54,7 +54,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 			continue
 		}
 
-		log.Printf("reconciling experiment %s with experiment ID %s and database ID %d", experiment.Name, experiment.ExperimentId, item.ID)
+		log.Printf("sync reconciling experiment %s with experiment ID %s and database ID %d", experiment.Name, experiment.ExperimentId, item.ID)
 		local, err := r.dataStores.Local.GetExperiment(ctx, experiment.ExperimentId)
 		if err != nil {
 			log.Printf("failed to fetch experiment %d from local store for sync reconciliation: %s", item.ID, err)
@@ -178,7 +178,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 		if err != nil {
 			log.Printf("failed to update experiment %d timestamp: %s", item.ID, err)
 		}
-		log.Printf("finished reconciling experiment %s with experiment ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
+		log.Printf("finished sync reconciling experiment %s with experiment ID %s and database ID %d", experiment.Name, experiment.ExperimentId, experiment.Id)
 	}
 }
 

--- a/api/internal/reconcilers/experiments/sync_reconciler.go
+++ b/api/internal/reconcilers/experiments/sync_reconciler.go
@@ -32,6 +32,7 @@ func (r *SyncReconciler) Resync(ctx context.Context, queue *reconciler.Reconcile
 	ids, err := r.db.Experiments().ListExperimentIDsForReconciliation(ctx, maxItems)
 	if err != nil {
 		log.Printf("failed to fetch experiments from local mlflow: %s", err)
+		return
 	}
 	for _, id := range ids {
 		queue.Add(id)
@@ -44,6 +45,7 @@ func (r *SyncReconciler) Resync(ctx context.Context, queue *reconciler.Reconcile
 }
 
 func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.ReconcileItem[int64]) {
+	log.Printf("sync reconciling %d experiments", len(items))
 	for _, item := range items {
 		experiment, err := r.db.Experiments().GetExperimentById(ctx, item.ID)
 		if err != nil {
@@ -109,6 +111,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 			continue
 		}
 		for _, run := range localRuns {
+			log.Printf("reconciling local run %s with run ID %s", run.Info.Name, run.Info.RunId)
 			found := false
 			updated := false
 			for _, remoteRun := range remoteRuns {
@@ -133,6 +136,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 			var remoteRunId string
 			if !found {
 				// Insert the run into the remote store
+				log.Printf("run %s with run ID %s not found in remote store, creating it", run.Info.Name, run.Info.RunId)
 				id, err := r.dataStores.Remote.CreateRun(ctx, experiment.RemoteExperimentId, run.Info.Name, util.TimeStamp(run.Info.StartTime), run.Data.Tags)
 				if err != nil {
 					log.Printf("failed to insert run %s with run ID %s into remote store: %s", run.Info.Name, run.Info.RunId, err)
@@ -150,9 +154,11 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 			}
 			var id int64
 			if existing != nil {
+				log.Printf("run %s with run ID %s found in DB with database ID %d", run.Info.Name, run.Info.RunId, existing.Id)
 				id = existing.Id
 			} else {
 				// Insert the run into the DB
+				log.Printf("run %s with run ID %s not found in DB, creating it", run.Info.Name, run.Info.RunId)
 				newRun, dberr := r.db.ExperimentRuns().CreateExperimentRun(ctx, &db.ExperimentRun{
 					Id:           0,
 					ExperimentId: run.Info.ExperimentId,
@@ -166,7 +172,7 @@ func (r *SyncReconciler) Reconcile(ctx context.Context, items []reconciler.Recon
 				id = newRun.Id
 			}
 			// Flag the run as ready for reconciliation
-			log.Printf("flagging run %s with run ID %s and database ID %d for reconciliation", run.Info.Name, run.Info.RunId, id)
+			log.Printf("flagging run %s with run ID %s and database ID %d for run reconciliation", run.Info.Name, run.Info.RunId, id)
 			dberr = r.db.ExperimentRuns().UpdateExperimentRunUpdatedAndTimestamp(ctx, id, true, time.Now())
 			if dberr != nil {
 				log.Printf("failed to update timestamp for run %s with run ID %s and database ID %d: %s", run.Info.Name, run.Info.RunId, id, dberr)

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -24,7 +24,7 @@ func (r *Reconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQueu
 	if !r.config.Enabled {
 		return
 	}
-	log.Debugln("beginning experiment run metrics reconciler resync")
+	log.Println("beginning experiment run metrics reconciler resync")
 
 	maxItems := int64(r.config.ResyncMaxItems)
 	runs, err := r.db.ExperimentRuns().ListExperimentRunIdsForMetricReconciliation(ctx, maxItems)
@@ -34,7 +34,7 @@ func (r *Reconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQueu
 	}
 
 	if len(runs) > 0 {
-		log.Debugf("queueing %d experiment runs for metric reconciliation", len(runs))
+		log.Printf("queueing %d experiment runs for metric reconciliation", len(runs))
 	}
 	for _, run := range runs {
 		queue.Add(run)

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -44,7 +44,7 @@ func (r *Reconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQueu
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.ReconcileItem[int64]) {
-	log.Debugf("reconciling %d experiment runs for metrics", len(items))
+	log.Printf("reconciling %d experiment runs for metrics", len(items))
 	for _, item := range items {
 		run, dberr := r.db.ExperimentRuns().GetExperimentRunById(ctx, item.ID)
 		if dberr != nil {

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -24,12 +24,12 @@ func (r *Reconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQueu
 	if !r.config.Enabled {
 		return
 	}
-	log.Println("beginning experiment run metrics reconciler resync")
+	log.Debugln("beginning experiment run metrics reconciler resync")
 
 	maxItems := int64(r.config.ResyncMaxItems)
 	runs, err := r.db.ExperimentRuns().ListExperimentRunIdsForMetricReconciliation(ctx, maxItems)
 	if err != nil {
-		log.Printf("failed to query database: %s", err)
+		log.Errorf("failed to query database: %s", err)
 		return
 	}
 

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -114,6 +114,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.Reconcile
 				})
 				if err != nil {
 					log.Printf("failed to insert text metric %s for experiment run %d: %s", artifact.Path, run.Id, err)
+					continue
 				} else {
 					log.Printf("inserted text metric %s with database ID %d for experiment run %s with database ID %d", textMetric.Name, textMetric.Id, run.RemoteRunId, run.Id)
 				}

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -69,16 +69,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.Reconcile
 			continue
 		}
 		for _, metric := range mlFlowMetrics {
-			name := metric.Key
-			lastIndex := strings.LastIndex(name, "/")
-			if lastIndex != -1 {
-				name = name[lastIndex+1:]
-			}
 			ts := time.Unix(0, metric.Timestamp*int64(time.Millisecond))
 			m, err := r.db.Metrics().CreateMetric(ctx, &db.Metric{
 				ExperimentId: run.ExperimentId,
 				RunId:        run.RunId,
-				Name:         name,
+				Name:         metric.Key,
 				Type:         db.MetricTypeNumeric,
 				ValueNumeric: &metric.Value,
 				Tags: map[string]string{
@@ -110,10 +105,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.Reconcile
 					continue
 				}
 				value := string(data)
+				log.Printf("found artifact %s", artifact.Path)
+				name := artifact.Path
+				lastIndex := strings.LastIndex(name, "/")
+				if lastIndex != -1 {
+					name = name[lastIndex+1:]
+				}
 				textMetric, err := r.db.Metrics().CreateMetric(ctx, &db.Metric{
 					ExperimentId: run.ExperimentId,
 					RunId:        run.RunId,
-					Name:         artifact.Path,
+					Name:         name,
 					Type:         db.MetricTypeText,
 					ValueText:    &value,
 				})

--- a/api/internal/reconcilers/metrics/reconciler.go
+++ b/api/internal/reconcilers/metrics/reconciler.go
@@ -69,11 +69,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, items []reconciler.Reconcile
 			continue
 		}
 		for _, metric := range mlFlowMetrics {
+			name := metric.Key
+			lastIndex := strings.LastIndex(name, "/")
+			if lastIndex != -1 {
+				name = name[lastIndex+1:]
+			}
 			ts := time.Unix(0, metric.Timestamp*int64(time.Millisecond))
 			m, err := r.db.Metrics().CreateMetric(ctx, &db.Metric{
 				ExperimentId: run.ExperimentId,
 				RunId:        run.RunId,
-				Name:         metric.Key,
+				Name:         name,
 				Type:         db.MetricTypeNumeric,
 				ValueNumeric: &metric.Value,
 				Tags: map[string]string{

--- a/api/internal/reconcilers/runs/runs_reconciler.go
+++ b/api/internal/reconcilers/runs/runs_reconciler.go
@@ -37,7 +37,7 @@ func (r *RunReconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQ
 	}
 
 	if len(ids) > 0 {
-		log.Debugf("queueing %d runs for reconciliation", len(ids))
+		log.Printf("queueing %d runs for reconciliation", len(ids))
 	}
 	log.Debugln("completing reconciler resync")
 }
@@ -266,6 +266,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, items []reconciler.Reconc
 		}
 
 		// Update the experiment run to indicate that metrics reconciliation is required
+		log.Printf("flagging run %s with run ID %s and database ID %d for metrics reconciliation", localRun.Info.Name, localRun.Info.RunId, item.ID)
 		err = r.db.ExperimentRuns().UpdateExperimentRunReconcileMetrics(ctx, run.Id, true)
 		if err != nil {
 			log.Printf("failed to update run %d reconcile metrics flag: %s", item.ID, err)

--- a/api/internal/reconcilers/runs/runs_reconciler.go
+++ b/api/internal/reconcilers/runs/runs_reconciler.go
@@ -321,5 +321,5 @@ func NewRunReconciler(config *Config, db db.Database, dataStores datasource.Data
 }
 
 func (r *RunReconciler) Name() string {
-	return "mlflow-run-reconciler"
+	return "runs-reconciler"
 }

--- a/api/internal/reconcilers/runs/runs_reconciler.go
+++ b/api/internal/reconcilers/runs/runs_reconciler.go
@@ -43,6 +43,7 @@ func (r *RunReconciler) Resync(ctx context.Context, queue *reconciler.ReconcileQ
 }
 
 func (r *RunReconciler) Reconcile(ctx context.Context, items []reconciler.ReconcileItem[int64]) {
+	log.Printf("reconciling %d experiment runs", len(items))
 	for _, item := range items {
 		run, err := r.db.ExperimentRuns().GetExperimentRunById(ctx, item.ID)
 		if err != nil {


### PR DESCRIPTION
- wait for mlflow to be ready prior to starting reconciliation
- ensure the reconcilers cleanly recover from errors
- ensure that artifact paths are trimmed to just the filename for metric naming