### PR TITLE
fix: disable collection of usage stats by streamlit on dev branch

### DIFF
--- a/ragmon/.streamlit/config.toml
+++ b/ragmon/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[browser]
+gatherUsageStats = false


### PR DESCRIPTION
- adds `ragmon/.streamlit/config.toml`
- disables collection of usage stats by streamlit